### PR TITLE
Use `strftime` Directly

### DIFF
--- a/lib/singed/flamegraph.rb
+++ b/lib/singed/flamegraph.rb
@@ -53,7 +53,7 @@ module Singed
     end
 
     def self.generate_filename(label: nil, time: Time.now) # rubocop:disable Rails/TimeZone
-      formatted_time = time.to_formatted_s(:number)
+      formatted_time = time.strftime('%Y%m%d%H%M%S')
       basename_parts = ['speedscope', label, formatted_time].compact
 
       file = Singed.output_directory.join("#{basename_parts.join('-')}.json")


### PR DESCRIPTION
Whilst `to_formatted_s(:number)` is more convenient than `strftime(wall_of_symbols)`, with this equivalent change this library is usable outside of Rails codebases.